### PR TITLE
エラーメッセージの日本語対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,3 +64,4 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 gem 'payjp'
 gem 'aws-sdk-s3', require: false
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,6 +194,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.5)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.6)
       actionpack (= 6.0.6)
       activesupport (= 6.0.6)
@@ -330,6 +333,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   sass-rails (~> 5)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,15 +1,15 @@
 class Item < ApplicationRecord
   with_options presence: true do
-    validates :name, length: { maximum: 40, message: 'is too long (maximum is 40 characters)' }
-    validates :description, length: { maximum: 1000, message: 'is too long (maximum is 1000 characters)' }
-    validates :category_id, numericality: { other_than: 0, message: "can't be blank" }
-    validates :condition_id, numericality: { other_than: 0, message: "can't be blank" }
-    validates :delivery_charge_id, numericality: { other_than: 0, message: "can't be blank" }
-    validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
-    validates :delivery_duration_id, numericality: { other_than: 0, message: "can't be blank" }
+    validates :name, length: { maximum: 40, message: 'は40文字以内で入力してください' }
+    validates :description, length: { maximum: 1000, message: 'は1000文字以内で入力してください' }
+    validates :category_id, numericality: { other_than: 0, message: "を入力してください" }
+    validates :condition_id, numericality: { other_than: 0, message: "を入力してください" }
+    validates :delivery_charge_id, numericality: { other_than: 0, message: "を入力してください" }
+    validates :prefecture_id, numericality: { other_than: 0, message: "を入力してください" }
+    validates :delivery_duration_id, numericality: { other_than: 0, message: "を入力してください" }
     validates :price,
               numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999,
-                              message: 'is invalid' }
+                              message: 'は300円から9,999,999円の間で半角数字で入力してください' }
     validates :image
   end
 

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -3,17 +3,17 @@ class OrderAddress
   attr_accessor :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number, :user_id, :item_id, :token
 
   with_options presence: true do
-    validates :postal_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'is invalid. Enter it as follows (e.g. 123-4567)' }
+    validates :postal_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'はハイフン(-)を含めて入力してください(例 123-4567)' }
     validates :city
     validates :house_number
-    validates :phone_number, numericality: { only_integer: true, message: 'is invalid. Input only number' },
-                             length: { minimum: 10, maximum: 11, message: 'is invalid. Input 10 or 11 character' }
+    validates :phone_number, numericality: { only_integer: true, message: 'は半角数字のみで入力してください(例 08012345678)' },
+                             length: { minimum: 10, maximum: 11, message: 'は10桁または11桁で入力してください' }
     validates :user_id
     validates :item_id
     validates :token
   end
 
-  validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
+  validates :prefecture_id, numericality: { other_than: 0, message: "を入力してください" }
 
   def save
     order = Order.create(user_id: user_id, item_id: item_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,17 +6,17 @@ class User < ApplicationRecord
 
   with_options presence: true do
     validates :nickname
-    validates :last_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'is invalid. Input with full-width characters' }
-    validates :first_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'is invalid. Input with full-width characters' }
-    validates :last_name_reading, format: { with: /\A[ァ-ヶ]+\z/, message: 'is invalid. Input with full-width katakana characters' }
+    validates :last_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'は全角で入力してください' }
+    validates :first_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'は全角で入力してください' }
+    validates :last_name_reading, format: { with: /\A[ァ-ヶ]+\z/, message: 'は全角カナで入力してください' }
     validates :first_name_reading,
-              format: { with: /\A[ァ-ヶ]+\z/, message: 'is invalid. Input with full-width katakana characters' }
+              format: { with: /\A[ァ-ヶ]+\z/, message: 'は全角カナで入力してください' }
     validates :birth_date
   end
 
   validates :password,
             format: { with: /\A(?=.*?[a-zA-Z])(?=.*?\d)[a-zA-Z\d]{6,}\z/,
-                      message: 'is invalid. Input with both half-width digits and alphabets' }
+                      message: 'は半角英数字両方を含めてください' }
 
   has_many :items
   has_many :orders

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module Furima38144
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # 日本語の言語設定
+    config.i18n.default_locale = :ja
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,32 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        last_name: 姓
+        first_name: 名
+        last_name_reading: 姓カナ
+        first_name_reading: 名カナ
+        birth_date: 生年月日
+      item:
+        image: 商品画像
+        name: 商品名
+        description: 商品の説明
+        category_id: カテゴリー
+        condition_id: 商品の状態
+        delivery_charge_id: 配送料の負担
+        prefecture_id: 発送元の地域
+        delivery_duration_id: 発送までの日数
+        price: 価格
+        user: ユーザー情報
+  activemodel:
+    attributes:
+      order_address:
+        token: クレジットカード情報
+        user_id: ユーザー情報
+        item_id: 商品情報
+        postal_code: 郵便番号
+        prefecture_id: 都道府県
+        city: 市区町村
+        house_number: 番地
+        phone_number: 電話番号

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -16,77 +16,77 @@ RSpec.describe Item, type: :model do
       it '商品画像を1枚つけることが必須であること' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include "Image can't be blank"
+        expect(@item.errors.full_messages).to include "商品画像を入力してください"
       end
       it '商品名が必須であること' do
         @item.name = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Name can't be blank"
+        expect(@item.errors.full_messages).to include "商品名を入力してください"
       end
       it '商品名が40文字以下であること' do
         @item.name = Faker::Lorem.characters(number: 41)
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Name is too long (maximum is 40 characters)'
+        expect(@item.errors.full_messages).to include '商品名は40文字以内で入力してください'
       end
       it '商品の説明が必須であること' do
         @item.description = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Description can't be blank"
+        expect(@item.errors.full_messages).to include "商品の説明を入力してください"
       end
       it '商品の説明が1000文字以下であること' do
         @item.description = Faker::Lorem.characters(number: 1001)
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Description is too long (maximum is 1000 characters)'
+        expect(@item.errors.full_messages).to include '商品の説明は1000文字以内で入力してください'
       end
       it 'カテゴリーの情報が必須であること' do
         @item.category_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include "Category can't be blank"
+        expect(@item.errors.full_messages).to include "カテゴリーを入力してください"
       end
       it '商品の状態の情報が必須であること' do
         @item.condition_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include "Condition can't be blank"
+        expect(@item.errors.full_messages).to include "商品の状態を入力してください"
       end
       it '配送料の負担の情報が必須であること' do
         @item.delivery_charge_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include "Delivery charge can't be blank"
+        expect(@item.errors.full_messages).to include "配送料の負担を入力してください"
       end
       it '発送元の地域の情報が必須であること' do
         @item.prefecture_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include "Prefecture can't be blank"
+        expect(@item.errors.full_messages).to include "発送元の地域を入力してください"
       end
       it '発送までの日数の情報が必須であること' do
         @item.delivery_duration_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include "Delivery duration can't be blank"
+        expect(@item.errors.full_messages).to include "発送までの日数を入力してください"
       end
       it '価格の情報が必須であること' do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price can't be blank"
+        expect(@item.errors.full_messages).to include "価格を入力してください"
       end
       it '価格は、¥300以下では保存できないこと' do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price is invalid'
+        expect(@item.errors.full_messages).to include '価格は300円から9,999,999円の間で半角数字で入力してください'
       end
       it '価格は、¥9,999,999以上では保存できないこと' do
         @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price is invalid'
+        expect(@item.errors.full_messages).to include '価格は300円から9,999,999円の間で半角数字で入力してください'
       end
       it '価格は半角数値のみ保存可能であること' do
         @item.price = '１０００'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price is invalid'
+        expect(@item.errors.full_messages).to include '価格は300円から9,999,999円の間で半角数字で入力してください'
       end
       it 'userが存在しなければ登録できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include 'User must exist'
+        expect(@item.errors.full_messages).to include 'ユーザー情報を入力してください'
       end
     end
   end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -22,72 +22,72 @@ RSpec.describe OrderAddress, type: :model do
       it '郵便番号が必須であること' do
         @order_address.postal_code = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "Postal code can't be blank"
+        expect(@order_address.errors.full_messages).to include "郵便番号を入力してください"
       end
       it '郵便番号は、「3桁ハイフン4桁」の半角文字列のみ保存可能なこと(ハイフンなし)' do
         @order_address.postal_code = '1234567'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include 'Postal code is invalid. Enter it as follows (e.g. 123-4567)'
+        expect(@order_address.errors.full_messages).to include '郵便番号はハイフン(-)を含めて入力してください(例 123-4567)'
       end
       it '郵便番号は、「3桁ハイフン4桁」の半角文字列のみ保存可能なこと(全角含む)' do
         @order_address.postal_code = '123ー4567'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include 'Postal code is invalid. Enter it as follows (e.g. 123-4567)'
+        expect(@order_address.errors.full_messages).to include '郵便番号はハイフン(-)を含めて入力してください(例 123-4567)'
       end
       it '都道府県が必須であること' do
         @order_address.prefecture_id = 0
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "Prefecture can't be blank"
+        expect(@order_address.errors.full_messages).to include "都道府県を入力してください"
       end
       it '市区町村が必須であること' do
         @order_address.city = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "City can't be blank"
+        expect(@order_address.errors.full_messages).to include "市区町村を入力してください"
       end
       it '番地が必須であること' do
         @order_address.house_number = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "House number can't be blank"
+        expect(@order_address.errors.full_messages).to include "番地を入力してください"
       end
       it '電話番号が必須であること' do
         @order_address.phone_number = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "Phone number can't be blank"
+        expect(@order_address.errors.full_messages).to include "電話番号を入力してください"
       end
       it '電話番号は、10桁以上11桁以内の半角数値のみ保存可能なこと（ハイフン込み）' do
         @order_address.phone_number = '090-1234-5678'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include 'Phone number is invalid. Input only number'
+        expect(@order_address.errors.full_messages).to include '電話番号は半角数字のみで入力してください(例 08012345678)'
       end
       it '電話番号は、10桁以上11桁以内の半角数値のみ保存可能なこと（全角込み）' do
         @order_address.phone_number = '０９０１２３４５６７８'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include 'Phone number is invalid. Input only number'
+        expect(@order_address.errors.full_messages).to include '電話番号は半角数字のみで入力してください(例 08012345678)'
       end
       it '電話番号は、10桁以上11桁以内の半角数値のみ保存可能なこと（10文字未満）' do
         @order_address.phone_number = '123456789'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include 'Phone number is invalid. Input 10 or 11 character'
+        expect(@order_address.errors.full_messages).to include '電話番号は10桁または11桁で入力してください'
       end
       it '電話番号は、10桁以上11桁以内の半角数値のみ保存可能なこと（12文字以上）' do
         @order_address.phone_number = '012345678901'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include 'Phone number is invalid. Input 10 or 11 character'
+        expect(@order_address.errors.full_messages).to include '電話番号は10桁または11桁で入力してください'
       end
       it 'user_idが空では購入できない' do
         @order_address.user_id = nil
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "User can't be blank"
+        expect(@order_address.errors.full_messages).to include "ユーザー情報を入力してください"
       end
       it 'item_idが空では購入できない' do
         @order_address.item_id = nil
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "Item can't be blank"
+        expect(@order_address.errors.full_messages).to include "商品情報を入力してください"
       end
       it 'tokenが空では購入できない' do
         @order_address.token = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "Token can't be blank"
+        expect(@order_address.errors.full_messages).to include "クレジットカード情報を入力してください"
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,54 +15,54 @@ RSpec.describe User, type: :model do
       it 'ニックネームが必須である' do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Nickname can't be blank"
+        expect(@user.errors.full_messages).to include "ニックネームを入力してください"
       end
       it 'メールアドレスが必須である' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Email can't be blank"
+        expect(@user.errors.full_messages).to include "Eメールを入力してください"
       end
       it 'メールアドレスが一意性である' do
         @user.save
         @email_test_user = FactoryBot.build(:user, email: @user.email)
         @email_test_user.valid?
-        expect(@email_test_user.errors.full_messages).to include 'Email has already been taken'
+        expect(@email_test_user.errors.full_messages).to include 'Eメールはすでに存在します'
       end
       it 'メールアドレスは、@を含む必要がある' do
         @user.email = 'testemail'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Email is invalid'
+        expect(@user.errors.full_messages).to include 'Eメールは不正な値です'
       end
       it 'パスワードが必須である' do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password can't be blank"
+        expect(@user.errors.full_messages).to include "パスワードを入力してください"
       end
       it 'パスワードは、6文字以上での入力が必須である' do
         @user.password = '123ab'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is too short (minimum is 6 characters)'
+        expect(@user.errors.full_messages).to include 'パスワードは6文字以上で入力してください'
       end
       it 'パスワードは、英字のみでは登録できない' do
         @user.password = 'testtest'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is invalid. Input with both half-width digits and alphabets'
+        expect(@user.errors.full_messages).to include 'パスワードは半角英数字両方を含めてください'
       end
       it 'パスワードは、数字のみでは登録できない' do
         @user.password = '12341234'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is invalid. Input with both half-width digits and alphabets'
+        expect(@user.errors.full_messages).to include 'パスワードは半角英数字両方を含めてください'
       end
       it 'パスワードは、全角文字を含むと登録できない' do
         @user.password = 'ＴＥＳＴ1234'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is invalid. Input with both half-width digits and alphabets'
+        expect(@user.errors.full_messages).to include 'パスワードは半角英数字両方を含めてください'
       end
       it 'パスワードとパスワード（確認）は、値の一致が必須である' do
         @user.password = '123abc'
         @user.password_confirmation = '123abcd'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password confirmation doesn't match Password"
+        expect(@user.errors.full_messages).to include "パスワード（確認用）とパスワードの入力が一致しません"
       end
     end
   end
@@ -72,47 +72,47 @@ RSpec.describe User, type: :model do
       it 'お名前(全角)は、名字が必須である' do
         @user.last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name can't be blank"
+        expect(@user.errors.full_messages).to include "姓を入力してください"
       end
       it 'お名前(全角)は、名前が必須である' do
         @user.first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "First name can't be blank"
+        expect(@user.errors.full_messages).to include "名を入力してください"
       end
       it 'お名前(全角)の名字は、全角（漢字・ひらがな・カタカナ）での入力が必須である' do
         @user.last_name = 'sato'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name is invalid. Input with full-width characters'
+        expect(@user.errors.full_messages).to include '姓は全角で入力してください'
       end
       it 'お名前(全角)の名前は、全角（漢字・ひらがな・カタカナ）での入力が必須である' do
         @user.first_name = 'taro'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name is invalid. Input with full-width characters'
+        expect(@user.errors.full_messages).to include '名は全角で入力してください'
       end
       it 'お名前カナ(全角)は、名字が必須である' do
         @user.last_name_reading = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name reading can't be blank"
+        expect(@user.errors.full_messages).to include "姓カナを入力してください"
       end
       it 'お名前カナ(全角)は、名前が必須である' do
         @user.first_name_reading = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "First name reading can't be blank"
+        expect(@user.errors.full_messages).to include "名カナを入力してください"
       end
       it 'お名前(全角)の名字は、全角（カタカナ）での入力が必須である' do
         @user.last_name_reading = 'さとう'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name reading is invalid. Input with full-width katakana characters'
+        expect(@user.errors.full_messages).to include '姓カナは全角カナで入力してください'
       end
       it 'お名前(全角)の名前は、全角（カタカナ）での入力が必須である' do
         @user.first_name_reading = 'たろう'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name reading is invalid. Input with full-width katakana characters'
+        expect(@user.errors.full_messages).to include '名カナは全角カナで入力してください'
       end
       it '生年月日が必須である' do
         @user.birth_date = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include "Birth date can't be blank"
+        expect(@user.errors.full_messages).to include "生年月日を入力してください"
       end
     end
   end


### PR DESCRIPTION
# What
- rails-i18nの導入
- config/locals/devise.ja.yml, ja.ymlの追加
- user, item, order_addressモデルのエラーメッセージと各モデル単体テストの修正

# Why
- エラーメッセージの日本語化のため

# 動作確認
- モデル単体テスト、本番環境での表示確認実行済み　※gyazoは枚数制限があるため、確認者がいない今回は添付しない